### PR TITLE
fix(java): strim the blind result, since the go server size is 66

### DIFF
--- a/bindings/java/secureunionid/src/main/java/com/volcengine/secureunionid/Demo.java
+++ b/bindings/java/secureunionid/src/main/java/com/volcengine/secureunionid/Demo.java
@@ -125,7 +125,12 @@ class Demo {
         System.out.println("--------------------------------------------------");
         System.out.println("Step 4: encrypt");
         byte cipherText0[] = new byte[PUBKEY_G1_LEN];
-        r = secureUnionID.Enc(privateKey, blindResult0, cipherText0);
+
+        System.out.printf("blind result length is %d\n", blindResult0.length);
+        // for the go server, the blind result size is 66 instead of 67.
+        String blindResultStr0 = new String(blindResult0).trim();
+        System.out.printf("After strim blind result length is %d\n", blindResultStr0.length());
+        r = secureUnionID.Enc(privateKey, blindResultStr0.getBytes(), cipherText0);
         if (r != 0) {
             System.out.printf("encrypt error %d\n", r);
             return;
@@ -133,7 +138,13 @@ class Demo {
         System.out.printf("encrypt result for device id 0: %s\n", bytesToHex(blindResult0));
 
         byte cipherText1[] = new byte[PUBKEY_G1_LEN];
-        r = secureUnionID.Enc(privateKey, blindResult1, cipherText1);
+        System.out.printf("blind result length is %d\n", blindResult1.length);
+        // for the go server, the blind result size is 66 instead of 67.
+        String blindResultStr1 = new String(blindResult1).trim();
+        System.out.printf("After strim blind result length is %d\n", blindResultStr1.length());
+
+
+        r = secureUnionID.Enc(privateKey, blindResultStr1.getBytes(), cipherText1);
         if (r != 0) {
             System.out.printf("encrypt error %d\n", r);
             return;

--- a/bindings/java/secureunionid/src/main/java/com/volcengine/secureunionid/SecureUnionID.java
+++ b/bindings/java/secureunionid/src/main/java/com/volcengine/secureunionid/SecureUnionID.java
@@ -25,6 +25,8 @@ public class SecureUnionID {
 
   // the length of public key on G1 group
   public static final int PUBKEY_G1_LEN = G1_LEN * 2 + 1;
+  // the length of blind result
+  public static final int BLIND_RESULT_LEN_STRIM = PUBKEY_G1_LEN - 1;
   // the length of public key on G2 group
   public static final int PUBKEY_G2_LEN = G2_LEN * 2 + 1;
 
@@ -186,7 +188,7 @@ public class SecureUnionID {
 
   public static int Enc(byte[] arg0, byte[] arg1, byte[] arg2) {
     if (arg0 == null || arg0.length < PRIVATE_KEY_LEN ||
-        arg1 == null || arg1.length < PUBKEY_G1_LEN ||
+        arg1 == null || arg1.length < BLIND_RESULT_LEN_STRIM ||
         arg2 == null || arg2.length < PUBKEY_G1_LEN)
         return JAVA_NULL_OR_LENGTH_ERROR;
     int r = SecureUnionIDJNI.Enc(arg0, arg1, arg2);


### PR DESCRIPTION
For the enc interface, the length of the blind result should be 66 instead of 67.